### PR TITLE
fix(core): Crash on calling teardown before server connection is ready

### DIFF
--- a/packages/fixture-injection/injector.js
+++ b/packages/fixture-injection/injector.js
@@ -14,6 +14,7 @@ class FixtureInjector {
   constructor(rootDir, useGlobalFixtureServer = false, ipcOptions = {}) {
     this.rootDir = rootDir
     this.useGlobalFixtureServer = useGlobalFixtureServer
+    this.connectionPromise = null
     this.ipcOptions = Object.assign({}, IPC_DEFAULT_OPTIONS, ipcOptions)
     this.fixturesPath = null
     this.globalFixturesPath = null
@@ -110,7 +111,7 @@ class FixtureInjector {
 
   setup() {
     if (this.useGlobalFixtureServer) {
-      return new Promise((connectionResolve) => {
+      this.connectionPromise = new Promise((connectionResolve) => {
         Object.assign(ipc.config, this.ipcOptions, { id: IPC_CLIENT_ID })
 
         ipc.connectTo(IPC_SERVER_ID, () => {
@@ -139,6 +140,7 @@ class FixtureInjector {
           })
         })
       })
+      return this.connectionPromise
     }
 
     this.dependencyMap = constructDependencyMap(
@@ -150,7 +152,7 @@ class FixtureInjector {
   teardown() {
     if (this.useGlobalFixtureServer) {
       return new Promise((resolve) => {
-        ipc.connectTo(IPC_SERVER_ID, () => {
+        this.connectionPromise.then(() => {
           ipc.of[IPC_SERVER_ID].on('disconnect', () => {
             resolve()
           })

--- a/packages/fixture-injection/injector.js
+++ b/packages/fixture-injection/injector.js
@@ -150,10 +150,12 @@ class FixtureInjector {
   teardown() {
     if (this.useGlobalFixtureServer) {
       return new Promise((resolve) => {
-        ipc.of[IPC_SERVER_ID].on('disconnect', () => {
-          resolve()
+        ipc.connectTo(IPC_SERVER_ID, () => {
+          ipc.of[IPC_SERVER_ID].on('disconnect', () => {
+            resolve()
+          })
+          ipc.disconnect(IPC_SERVER_ID)
         })
-        ipc.disconnect(IPC_SERVER_ID)
       })
     }
 

--- a/packages/jest-fixture-injection-tests/early-teardown/__fixtures__.js
+++ b/packages/jest-fixture-injection-tests/early-teardown/__fixtures__.js
@@ -1,0 +1,37 @@
+const f = async (provide, c) => {
+  await provide(`F(${c})`)
+}
+
+const g = async (provide, c, d) => {
+  await provide(`G(${c},${d})`)
+}
+
+const h = async (provide) => {
+  await provide('H()')
+}
+
+const i = async (provide, d, e) => {
+  await provide(`I(${d},${e})`)
+}
+
+const j = async (provide, e) => {
+  await provide(`J(${e})`)
+}
+
+const k = async (provide, f, h) => {
+  await provide(`K(${f},${h})`)
+}
+
+const l = async (provide, h, j) => {
+  await provide(`L(${h},${j})`)
+}
+
+module.exports = {
+  f,
+  g,
+  h,
+  i,
+  j,
+  k,
+  l
+}

--- a/packages/jest-fixture-injection-tests/early-teardown/__global_fixtures__.js
+++ b/packages/jest-fixture-injection-tests/early-teardown/__global_fixtures__.js
@@ -1,0 +1,27 @@
+const a = async (provide) => {
+  await provide('A()')
+}
+
+const b = async (provide) => {
+  await provide('B()')
+}
+
+const c = async (provide) => {
+  await provide('C()')
+}
+
+const d = async (provide, a, b) => {
+  await provide(`D(${a},${b})`)
+}
+
+const e = async (provide) => {
+  await provide('E()')
+}
+
+module.exports = {
+  a,
+  b,
+  c,
+  d,
+  e
+}

--- a/packages/jest-fixture-injection-tests/early-teardown/early-teardown.test.js
+++ b/packages/jest-fixture-injection-tests/early-teardown/early-teardown.test.js
@@ -1,0 +1,7 @@
+describe('Teardown which is called very early (w/o any async call)', () => {
+  fixture('foo', jest.fn(() => 'FOO'))
+
+  test('succeeds', (foo) => {
+    expect(foo).toEqual('FOO')
+  })
+})

--- a/packages/jest-fixture-injection-tests/early-teardown/fixture-injection.config.js
+++ b/packages/jest-fixture-injection-tests/early-teardown/fixture-injection.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  fixtures: '<rootDir>/__fixtures__',
+  globalFixtures: '<rootDir>/__global_fixtures__',
+  ipc: {
+    appspace: 'async-jsdom'
+  }
+}

--- a/packages/jest-fixture-injection-tests/early-teardown/jest.config.js
+++ b/packages/jest-fixture-injection-tests/early-teardown/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'jest-fixture-injection',
+  testEnvironment: 'jest-fixture-injection/jsdom'
+}

--- a/packages/jest-fixture-injection-tests/package.json
+++ b/packages/jest-fixture-injection-tests/package.json
@@ -11,6 +11,7 @@
     "test-sync-node": "scripty",
     "test-async-node": "scripty",
     "test-reuse-node": "scripty",
+    "test-early-teardown": "scripty",
     "pre-commit": "lint-staged && yarn test"
   },
   "lint-staged": {

--- a/packages/jest-fixture-injection-tests/scripts/test
+++ b/packages/jest-fixture-injection-tests/scripts/test
@@ -8,6 +8,8 @@ yarn test-sync-node --verbose
 yarn test-async-node --verbose
 yarn test-reuse-node --verbose
 
+yarn test-early-teardown --verbose
+
 JEST_CIRCUS=1 yarn test-sync-jsdom --verbose
 JEST_CIRCUS=1 yarn test-async-jsdom --verbose
 JEST_CIRCUS=1 yarn test-reuse-jsdom --verbose
@@ -15,3 +17,5 @@ JEST_CIRCUS=1 yarn test-reuse-jsdom --verbose
 JEST_CIRCUS=1 yarn test-sync-node --verbose
 JEST_CIRCUS=1 yarn test-async-node --verbose
 JEST_CIRCUS=1 yarn test-reuse-node --verbose
+
+JEST_CIRCUS=1 yarn test-early-teardown --verbose

--- a/packages/jest-fixture-injection-tests/scripts/test-early-teardown
+++ b/packages/jest-fixture-injection-tests/scripts/test-early-teardown
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+FIXTURE_INJECTION_CONFIG=early-teardown/fixture-injection.config.js \
+jest -c early-teardown/jest.config.js $@


### PR DESCRIPTION
Fix Jest teardown may crash when all test suites finish before the server connection is ready.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Let `FixtureInjector .teardown()` wait the until the server connection is ready.
Without it, Jest globalTeardown may crash when all test suites finish before the connection is ready.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See the description.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add `jest-fixture-injection-tests/early-teardown` which is a test suite finished very early without calling async functions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
